### PR TITLE
fix "Margin" translation

### DIFF
--- a/ja_JP.csv
+++ b/ja_JP.csv
@@ -6942,8 +6942,8 @@ Manual,手動
 Manual Selection,手動選択
 Manually,手動
 Map,マップ
-Margin,余白
-Margins and Padding,余白と余白
+Margin,マージン
+Margins and Padding,マージンとパディング
 Mark as Read,既読にする
 Marked as suspect. The billing or shipping address is similar to an address previously marked as suspect,疑わしいとマークされています。請求または配送先住所は、以前に疑わしいとマークされた住所と似ています
 Marketing,マーケティング

--- a/ja_JP.csv
+++ b/ja_JP.csv
@@ -6942,7 +6942,7 @@ Manual,手動
 Manual Selection,手動選択
 Manually,手動
 Map,マップ
-Margin,利益
+Margin,余白
 Margins and Padding,余白と余白
 Mark as Read,既読にする
 Marked as suspect. The billing or shipping address is similar to an address previously marked as suspect,疑わしいとマークされています。請求または配送先住所は、以前に疑わしいとマークされた住所と似ています


### PR DESCRIPTION
Marginは利益ではなく、余白ですね。
Page Builderの下図のところで誤訳になっていました。

![image](https://github.com/magentoj/language-ja_JP/assets/124136/b3927786-7711-410b-9b24-bfe9421a59c9)
